### PR TITLE
Fix TTL cleanup in MemoryStore

### DIFF
--- a/src/lib/strategies/MemoryStore/MemoryStore.ts
+++ b/src/lib/strategies/MemoryStore/MemoryStore.ts
@@ -166,17 +166,21 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
       );
     }
 
+    let expiresAt: number | undefined;
     if (!ignoreTTL) {
       if (!ttl && this.#options.defaultTTL) {
         ttl = this.#options.defaultTTL;
+      }
+      if (ttl) {
+        expiresAt = Date.now() + ttl;
       }
     }
 
     this.#storeData.set(key, data);
 
-    if (!ignoreTTL && ttl) {
+    if (!ignoreTTL && expiresAt) {
       try {
-        this.#expiringKeys.set(key, ttl);
+        this.#expiringKeys.set(key, expiresAt);
       } catch (err) {
         // revert stored key/value if setting expiration fails
         this.#storeData.delete(key);
@@ -197,6 +201,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
       throw new InvalidArgument('cannot delete value without a key');
     }
 
+    this.#expiringKeys.delete(key);
     return this.#storeData.delete(key);
   }
 

--- a/src/lib/strategies/MemoryStore/MemoryStore.ts
+++ b/src/lib/strategies/MemoryStore/MemoryStore.ts
@@ -178,7 +178,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
 
     this.#storeData.set(key, data);
 
-    if (!ignoreTTL && expiresAt) {
+    if (!ignoreTTL && expiresAt !== undefined) {
       try {
         this.#expiringKeys.set(key, expiresAt);
       } catch (err) {

--- a/test/unit_tests/MemoryStore.test.ts
+++ b/test/unit_tests/MemoryStore.test.ts
@@ -157,6 +157,32 @@ describe('store', () => {
     expect(() => store.set(new Date(), data)).toThrowError(MaxSizeReached);
   });
 
+  describe('expiration handling', () => {
+    it('should expire keys based on ttl', () => {
+      jest.useFakeTimers();
+
+      const storeKey = 'TTL_TEST';
+      cacheStores.addStore(
+        storeKey,
+        new MemoryStore({defaultTTL: 50, maxKeys: 0, ttlCheckTimer: 10})
+      );
+
+      const store = cacheStores.getStore(storeKey) as MemoryStore<MDataType, Date>;
+      const {key, data} = createBasic();
+
+      store.set(key, data, false, 30);
+
+      jest.advanceTimersByTime(20);
+      expect(store.get(key)).toEqual(data);
+
+      jest.advanceTimersByTime(20);
+      jest.runOnlyPendingTimers();
+      expect(store.get(key)).toBeUndefined();
+
+      jest.useRealTimers();
+    });
+  });
+
   describe('with no expiration', () => {
     it('should be implemented', () => {
       // TODO: Add no expiration specific tests


### PR DESCRIPTION
## Summary
- adjust TTL storage so keys expire correctly
- remove expiring TTL entries when deleting keys
- add unit test covering TTL expiry

## Testing
- `npm test` *(fails: missing dependencies and tsconfig)*

------
https://chatgpt.com/codex/tasks/task_e_6840663b12d08330abc2a9931a446e15