### PR TITLE
Fix comment typo in CacheContainer

### DIFF
--- a/src/lib/CacheContainer.ts
+++ b/src/lib/CacheContainer.ts
@@ -49,7 +49,7 @@ export class CacheContainer {
   }
 
   /**
-   * returns the keys of all cahce stores in container
+   * returns the keys of all cache stores in container
    * @returns
    */
   getKeys(): string[] {


### PR DESCRIPTION
## Summary
- correct spelling of "cache" in `getKeys` comment

## Testing
- `npx prettier --write src/lib/CacheContainer.ts`

------
https://chatgpt.com/codex/tasks/task_e_68407e8afd588330a105be6eab0279eb