### PR TITLE
test: validate removeStore key type

### DIFF
--- a/test/unit_tests/CacheContainer.test.ts
+++ b/test/unit_tests/CacheContainer.test.ts
@@ -100,11 +100,9 @@ describe('factory', () => {
   });
 
   it('should throw InvalidArgument when removing store with non-string key', () => {
-    const s = createBasicStore();
-
     getInvalidKeys().forEach(ik => {
       expect(() => {
-        cacheStores.addStore(ik as string, s);
+        cacheStores.removeStore(ik as string);
       }).toThrowError(InvalidArgument);
     });
   });


### PR DESCRIPTION
## Summary
- test removing stores with invalid keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68407eb542ec83309d80162788beb826