### PR TITLE
fix: handle TTL expiration correctly

### DIFF
--- a/test/unit_tests/MemoryStore.test.ts
+++ b/test/unit_tests/MemoryStore.test.ts
@@ -181,6 +181,30 @@ describe('store', () => {
 
       jest.useRealTimers();
     });
+
+    it('should expire keys with custom ttl even when default ttl is 0', () => {
+      jest.useFakeTimers();
+
+      const storeKey = 'CUSTOM_TTL_TEST';
+      cacheStores.addStore(
+        storeKey,
+        new MemoryStore({defaultTTL: 0, maxKeys: 0, ttlCheckTimer: 10})
+      );
+
+      const store = cacheStores.getStore(storeKey) as MemoryStore<MDataType, Date>;
+      const {key, data} = createBasic();
+
+      store.set(key, data, false, 30);
+
+      jest.advanceTimersByTime(20);
+      expect(store.get(key)).toEqual(data);
+
+      jest.advanceTimersByTime(20);
+      jest.runOnlyPendingTimers();
+      expect(store.get(key)).toBeUndefined();
+
+      jest.useRealTimers();
+    });
   });
 
   describe('with no expiration', () => {


### PR DESCRIPTION
## Summary
- fix TTL handling when setting data
- allow TTL validation to start even without default TTL
- add tests for custom TTL with no default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68407e99f7c8833089a77f7b1d8fbf3f