### PR TITLE
Add redis client access

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,3 @@
 {
-  "extends": "./node_modules/gts/",
-  "ignorePatterns": [
-    "dev.build",
-    "docs",
-    "build",
-    "example"
-  ]
+  "extends": "./node_modules/gts/"
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A cache service factory written in Node.js and TypeScript. It ships with an in-m
 
 - **CacheContainer** – register and retrieve multiple stores by key
 - **MemoryStore** – in-memory cache with TTL support and hit/miss statistics
+- **RedisStore** – wrapper around a Redis client with TTL support and direct client access
 - Custom errors for invalid arguments, duplicate keys and size limits
 - Fully typed API with tests covering core behaviour
 
@@ -25,7 +26,7 @@ The test suite compiles the TypeScript sources and runs Jest. Execute:
 pnpm test
 ```
 
-All tests should pass (52 tests across four suites). The lint step that follows may fail on newer Node versions.
+All tests should pass (58 tests across six suites). The lint step that follows may fail on newer Node versions.
 
 ## Example
 
@@ -47,4 +48,4 @@ console.log(store.get(new Date()));
 - ~~add actual tests~~
 - get 100% code coverage
 - create detailed readme
-- create cache store for redis client
+- ~~create cache store for redis client~~

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './lib/CacheContainer';
 export * from './lib/strategies/MemoryStore/MemoryStore';
+export * from './lib/strategies/RedisStore/RedisStore';

--- a/src/lib/CacheContainer.ts
+++ b/src/lib/CacheContainer.ts
@@ -61,7 +61,7 @@ export class CacheContainer {
    * @param key
    * @returns
    */
-  removeStore(key: string, shouldFlush = false): boolean {
+  async removeStore(key: string, shouldFlush = false): Promise<boolean> {
     if (typeof key !== 'string') {
       throw new InvalidArgument('a valid key is required to delete a store');
     }
@@ -71,7 +71,7 @@ export class CacheContainer {
     if (!store) return true;
 
     if (shouldFlush) {
-      store.flushAll();
+      await store.flushAll();
     }
 
     return this.#stores.delete(key);

--- a/src/lib/strategies/BaseCacheStrategy.ts
+++ b/src/lib/strategies/BaseCacheStrategy.ts
@@ -13,7 +13,7 @@ export interface BaseCacheStrategy<DataType, CacheKeyType> {
    * returns cached item from store by key
    * @param key identifier of cached data in store
    */
-  get(key: CacheKeyType): DataType | undefined;
+  get(key: CacheKeyType): Promise<DataType | undefined>;
 
   /**
    * sets data in the cache store
@@ -27,21 +27,26 @@ export interface BaseCacheStrategy<DataType, CacheKeyType> {
     data: DataType,
     ignoreTTL?: boolean,
     ttl?: number,
-  ): boolean;
+  ): Promise<boolean>;
 
   /**
    * hard deletes the identified data from store
    * @param key identifier of cached data in store
    */
-  del(key: CacheKeyType): boolean;
+  del(key: CacheKeyType): Promise<boolean>;
 
   /**
    * Remove all the keys/data from the store
    */
-  flushAll(): boolean;
+  flushAll(): Promise<boolean>;
 
   /**
    * returns total number of keys in the store
    */
-  getSize(): number;
+  getSize(): Promise<number>;
+
+  /**
+   * returns all keys stored in the cache
+   */
+  getKeys(): Promise<CacheKeyType[]>;
 }

--- a/src/lib/strategies/MemoryStore/MemoryStore.ts
+++ b/src/lib/strategies/MemoryStore/MemoryStore.ts
@@ -127,7 +127,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
    * @param key key for the key/value pair in store map
    * @returns value from the cache of type DT or undefined if nothing found
    */
-  get(key: CKT): DT | undefined {
+  async get(key: CKT): Promise<DT | undefined> {
     if (!key) {
       throw new InvalidArgument('cannot get value without a key');
     }
@@ -151,7 +151,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
    * @param ttl if passed, it will set a custom expiration time for the key/value in store
    * @returns boolean indicating, if storing the key/value in store pair was successful or not
    */
-  set(key: CKT, data: DT, ignoreTTL = false, ttl?: number): boolean {
+  async set(key: CKT, data: DT, ignoreTTL = false, ttl?: number): Promise<boolean> {
     if (key === undefined) {
       throw new InvalidArgument('cannot set value without a key');
     }
@@ -160,7 +160,10 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
       throw new InvalidArgument('cannot set undefined or null');
     }
 
-    if (this.#options.maxKeys > 0 && this.getSize() === this.#options.maxKeys) {
+    if (
+      this.#options.maxKeys > 0 &&
+      (await this.getSize()) === this.#options.maxKeys
+    ) {
       throw new MaxSizeReached(
         `max keys limit: ${
           this.#options.maxKeys
@@ -201,7 +204,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
    * @param key key for the key/value pair in store map
    * @returns a boolean, indicating if deleting the key/value was successful or not
    */
-  del(key: CKT): boolean {
+  async del(key: CKT): Promise<boolean> {
     if (key === undefined) {
       throw new InvalidArgument('cannot delete value without a key');
     }
@@ -214,7 +217,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
    * Flushes / removes all the data from store, resets the stats and restarts the key/value expiry timeout
    * @returns a boolean, indicating if flushing the whole store was successful or not
    */
-  flushAll(): boolean {
+  async flushAll(): Promise<boolean> {
     this.#stopTTLValidation();
 
     this.#storeData = new Map();
@@ -230,7 +233,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
    * gets all the keys that are present in store
    * @returns all the keys from the store
    */
-  getKeys(): CKT[] {
+  async getKeys(): Promise<CKT[]> {
     return [...this.#storeData.keys()];
   }
 
@@ -238,7 +241,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
    * returns size(length) of the store
    * @returns how many key/value pairs are stored in store
    */
-  getSize(): number {
+  async getSize(): Promise<number> {
     return this.#storeData.size;
   }
 

--- a/src/lib/strategies/MemoryStore/MemoryStore.ts
+++ b/src/lib/strategies/MemoryStore/MemoryStore.ts
@@ -93,7 +93,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
     this.#ttlTimeout = setInterval(() => {
       this.#expiringKeys.forEach((keyTTL, key) => {
         if (this.#keyIsExpired(keyTTL)) {
-          this.del(key);
+          void this.del(key);
         }
       });
     }, timer);
@@ -133,7 +133,7 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
     }
 
     if (this.#keyIsExpired(this.#expiringKeys.get(key))) {
-      this.del(key);
+      void this.del(key);
     }
 
     const data = this.#storeData.get(key);
@@ -151,7 +151,12 @@ export class MemoryStore<DT, CKT> implements BaseCacheStrategy<DT, CKT> {
    * @param ttl if passed, it will set a custom expiration time for the key/value in store
    * @returns boolean indicating, if storing the key/value in store pair was successful or not
    */
-  async set(key: CKT, data: DT, ignoreTTL = false, ttl?: number): Promise<boolean> {
+  async set(
+    key: CKT,
+    data: DT,
+    ignoreTTL = false,
+    ttl?: number,
+  ): Promise<boolean> {
     if (key === undefined) {
       throw new InvalidArgument('cannot set value without a key');
     }

--- a/src/lib/strategies/RedisStore/RedisStore.ts
+++ b/src/lib/strategies/RedisStore/RedisStore.ts
@@ -1,0 +1,115 @@
+import {BaseCacheStrategy} from '../BaseCacheStrategy';
+import {InvalidArgument} from '../../common/errors/InvalidArgument';
+import {Stats} from '../MemoryStore/Stats';
+
+export interface RedisClientLike {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string, ...args: unknown[]): Promise<unknown>;
+  del(key: string): Promise<number>;
+  keys(pattern: string): Promise<string[]>;
+  flushDb(): Promise<unknown>;
+}
+
+export interface RedisStoreOptions {
+  defaultTTL?: number;
+}
+
+export class RedisStore<DT> implements BaseCacheStrategy<DT, string> {
+  #client: RedisClientLike;
+  #stats: Stats;
+  #options: RedisStoreOptions;
+
+  constructor(client: RedisClientLike, options: RedisStoreOptions = {}) {
+    this.#client = client;
+    this.#options = options;
+    this.#stats = {hits: 0, misses: 0};
+  }
+
+  /**
+   * Exposes the underlying redis client for advanced use cases
+   * @returns the internal client instance
+   */
+  getClient(): RedisClientLike {
+    return this.#client;
+  }
+
+  getHits(): number {
+    return this.#stats.hits;
+  }
+
+  getMisses(): number {
+    return this.#stats.misses;
+  }
+
+  async get(key: string): Promise<DT | undefined> {
+    if (!key) {
+      throw new InvalidArgument('cannot get value without a key');
+    }
+
+    const data = await this.#client.get(key);
+    if (data === null) {
+      ++this.#stats.misses;
+      return undefined;
+    }
+
+    ++this.#stats.hits;
+    try {
+      return JSON.parse(data) as DT;
+    } catch {
+      return (data as unknown) as DT;
+    }
+  }
+
+  async set(
+    key: string,
+    data: DT,
+    ignoreTTL = false,
+    ttl?: number,
+  ): Promise<boolean> {
+    if (!key) {
+      throw new InvalidArgument('cannot set value without a key');
+    }
+    if (data === undefined || data === null) {
+      throw new InvalidArgument('cannot set undefined or null');
+    }
+
+    const payload = JSON.stringify(data);
+    const args: unknown[] = [];
+
+    if (!ignoreTTL) {
+      if (!ttl && this.#options.defaultTTL) {
+        ttl = this.#options.defaultTTL;
+      }
+      if (ttl) {
+        args.push('PX', ttl);
+      }
+    }
+
+    await this.#client.set(key, payload, ...args);
+    return true;
+  }
+
+  async del(key: string): Promise<boolean> {
+    if (!key) {
+      throw new InvalidArgument('cannot delete value without a key');
+    }
+    const res = await this.#client.del(key);
+    return res > 0;
+  }
+
+  async flushAll(): Promise<boolean> {
+    await this.#client.flushDb();
+    this.#stats = {hits: 0, misses: 0};
+    return true;
+  }
+
+  async getSize(): Promise<number> {
+    const keys = await this.#client.keys('*');
+    return keys.length;
+  }
+
+  async getKeys(): Promise<string[]> {
+    return this.#client.keys('*');
+  }
+}
+

--- a/src/lib/strategies/RedisStore/RedisStore.ts
+++ b/src/lib/strategies/RedisStore/RedisStore.ts
@@ -56,7 +56,7 @@ export class RedisStore<DT> implements BaseCacheStrategy<DT, string> {
     try {
       return JSON.parse(data) as DT;
     } catch {
-      return (data as unknown) as DT;
+      return data as unknown as DT;
     }
   }
 
@@ -112,4 +112,3 @@ export class RedisStore<DT> implements BaseCacheStrategy<DT, string> {
     return this.#client.keys('*');
   }
 }
-

--- a/test/unit_tests/CacheContainer.test.ts
+++ b/test/unit_tests/CacheContainer.test.ts
@@ -128,7 +128,10 @@ describe('factory', () => {
     cacheStores.addStore(storeToRemoveKey, createBasicStore());
     const keysBeforeRemoval = cacheStores.getKeys();
 
-    const storeIsRemoved = await cacheStores.removeStore(storeToRemoveKey, true);
+    const storeIsRemoved = await cacheStores.removeStore(
+      storeToRemoveKey,
+      true,
+    );
 
     expect(storeIsRemoved).toEqual(true);
     expect(cacheStores.getKeys().length).toBeLessThan(keysBeforeRemoval.length);

--- a/test/unit_tests/CacheContainer.test.ts
+++ b/test/unit_tests/CacheContainer.test.ts
@@ -99,12 +99,12 @@ describe('factory', () => {
     });
   });
 
-  it('should throw InvalidArgument when removing store with non-string key', () => {
-    getInvalidKeys().forEach(ik => {
-      expect(() => {
-        cacheStores.removeStore(ik as string);
-      }).toThrowError(InvalidArgument);
-    });
+  it('should throw InvalidArgument when removing store with non-string key', async () => {
+    for (const ik of getInvalidKeys()) {
+      await expect(cacheStores.removeStore(ik as string)).rejects.toThrowError(
+        InvalidArgument,
+      );
+    }
   });
 
   it('should throw error when getting store with invalid key', () => {
@@ -115,20 +115,20 @@ describe('factory', () => {
     });
   });
 
-  it('should throw error when removing store without a valid key', () => {
+  it('should throw error when removing store without a valid key', async () => {
     const key: unknown = undefined;
 
-    expect(() => {
-      cacheStores.removeStore(key as string);
-    }).toThrowError(InvalidArgument);
+    await expect(cacheStores.removeStore(key as string)).rejects.toThrowError(
+      InvalidArgument,
+    );
   });
 
-  it('should allow removing a store by valid key', () => {
+  it('should allow removing a store by valid key', async () => {
     const storeToRemoveKey = 'TO_REMOVE_STORE';
     cacheStores.addStore(storeToRemoveKey, createBasicStore());
     const keysBeforeRemoval = cacheStores.getKeys();
 
-    const storeIsRemoved = cacheStores.removeStore(storeToRemoveKey, true);
+    const storeIsRemoved = await cacheStores.removeStore(storeToRemoveKey, true);
 
     expect(storeIsRemoved).toEqual(true);
     expect(cacheStores.getKeys().length).toBeLessThan(keysBeforeRemoval.length);
@@ -137,10 +137,10 @@ describe('factory', () => {
     }).toThrowError(NotFound);
   });
 
-  it('should return true if no store found', () => {
+  it('should return true if no store found', async () => {
     const storeToRemoveKey = 'RANDOM_STORE_KEY';
 
-    const storeIsRemoved = cacheStores.removeStore(storeToRemoveKey);
+    const storeIsRemoved = await cacheStores.removeStore(storeToRemoveKey);
 
     expect(storeIsRemoved).toEqual(true);
     expect(() => {

--- a/test/unit_tests/MemoryStore.test.ts
+++ b/test/unit_tests/MemoryStore.test.ts
@@ -39,7 +39,7 @@ describe('store', () => {
     expect(store.getHits()).toBe(0);
     expect(store.getMisses()).toBe(0);
     expect(await store.getSize()).toBe(0);
-    expect((await store.getKeys())).toHaveLength(0);
+    expect(await store.getKeys()).toHaveLength(0);
   });
 
   it('should return undefined when tried to get non-inserted item', async () => {
@@ -150,7 +150,9 @@ describe('store', () => {
     await store.set(key, data);
     await store.set(new Date(), data);
 
-    await expect(store.set(new Date(), data)).rejects.toThrowError(MaxSizeReached);
+    await expect(store.set(new Date(), data)).rejects.toThrowError(
+      MaxSizeReached,
+    );
   });
 
   describe('expiration handling', () => {
@@ -160,10 +162,13 @@ describe('store', () => {
       const storeKey = 'TTL_TEST';
       cacheStores.addStore(
         storeKey,
-        new MemoryStore({defaultTTL: 50, maxKeys: 0, ttlCheckTimer: 10})
+        new MemoryStore({defaultTTL: 50, maxKeys: 0, ttlCheckTimer: 10}),
       );
 
-      const store = cacheStores.getStore(storeKey) as MemoryStore<MDataType, Date>;
+      const store = cacheStores.getStore(storeKey) as MemoryStore<
+        MDataType,
+        Date
+      >;
       const {key, data} = createBasic();
 
       await store.set(key, data, false, 30);
@@ -184,10 +189,13 @@ describe('store', () => {
       const storeKey = 'CUSTOM_TTL_TEST';
       cacheStores.addStore(
         storeKey,
-        new MemoryStore({defaultTTL: 0, maxKeys: 0, ttlCheckTimer: 10})
+        new MemoryStore({defaultTTL: 0, maxKeys: 0, ttlCheckTimer: 10}),
       );
 
-      const store = cacheStores.getStore(storeKey) as MemoryStore<MDataType, Date>;
+      const store = cacheStores.getStore(storeKey) as MemoryStore<
+        MDataType,
+        Date
+      >;
       const {key, data} = createBasic();
 
       await store.set(key, data, false, 30);

--- a/test/unit_tests/RedisStore.test.ts
+++ b/test/unit_tests/RedisStore.test.ts
@@ -1,0 +1,86 @@
+import {CacheContainer} from '../../src/lib/CacheContainer';
+import {RedisStore, RedisClientLike} from '../../src/lib/strategies/RedisStore/RedisStore';
+
+interface DataType {
+  name: string;
+}
+
+class FakeRedisClient implements RedisClientLike {
+  private store = new Map<string, {value: string; expiresAt?: number}>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiresAt && entry.expiresAt <= Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key: string, value: string, ...args: unknown[]): Promise<unknown> {
+    let ttl: number | undefined;
+    if (args[0] === 'PX') {
+      ttl = Number(args[1]);
+    }
+    const expiresAt = ttl ? Date.now() + ttl : undefined;
+    this.store.set(key, {value, expiresAt});
+    return 'OK';
+  }
+
+  async del(key: string): Promise<number> {
+    const existed = this.store.delete(key);
+    return existed ? 1 : 0;
+  }
+
+  async keys(_pattern: string): Promise<string[]> {
+    this.cleanup();
+    return Array.from(this.store.keys());
+  }
+
+  async flushDb(): Promise<unknown> {
+    this.store.clear();
+    return 'OK';
+  }
+
+  private cleanup() {
+    const now = Date.now();
+    for (const [k, v] of this.store.entries()) {
+      if (v.expiresAt && v.expiresAt <= now) {
+        this.store.delete(k);
+      }
+    }
+  }
+}
+
+describe('RedisStore', () => {
+  const container = new CacheContainer();
+  const client = new FakeRedisClient();
+  const storeKey = 'redis';
+  container.addStore(storeKey, new RedisStore<DataType>(client));
+  const store = container.getStore(storeKey) as RedisStore<DataType>;
+
+  it('should set and get values', async () => {
+    await store.flushAll();
+    await store.set('a', {name: 'ali'});
+    const data = await store.get('a');
+    expect(data).toEqual({name: 'ali'});
+    expect(store.getHits()).toBe(1);
+  });
+
+  it('should expire keys using ttl', async () => {
+    jest.useFakeTimers();
+    await store.flushAll();
+    await store.set('b', {name: 'bob'}, false, 10);
+    expect(await store.get('b')).toEqual({name: 'bob'});
+    jest.advanceTimersByTime(20);
+    jest.runOnlyPendingTimers();
+    expect(await store.get('b')).toBeUndefined();
+    jest.useRealTimers();
+  });
+
+  it('should expose the underlying client', () => {
+    expect(store.getClient()).toBe(client);
+  });
+});
+

--- a/test/unit_tests/RedisStore.test.ts
+++ b/test/unit_tests/RedisStore.test.ts
@@ -1,5 +1,9 @@
 import {CacheContainer} from '../../src/lib/CacheContainer';
-import {RedisStore, RedisClientLike} from '../../src/lib/strategies/RedisStore/RedisStore';
+import {
+  RedisStore,
+  RedisClientLike,
+} from '../../src/lib/strategies/RedisStore/RedisStore';
+import {InvalidArgument} from '../../src/lib/common/errors/InvalidArgument';
 
 interface DataType {
   name: string;
@@ -33,7 +37,10 @@ class FakeRedisClient implements RedisClientLike {
     return existed ? 1 : 0;
   }
 
-  async keys(_pattern: string): Promise<string[]> {
+  async keys(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _pattern: string,
+  ): Promise<string[]> {
     this.cleanup();
     return Array.from(this.store.keys());
   }
@@ -54,11 +61,18 @@ class FakeRedisClient implements RedisClientLike {
 }
 
 describe('RedisStore', () => {
-  const container = new CacheContainer();
-  const client = new FakeRedisClient();
-  const storeKey = 'redis';
-  container.addStore(storeKey, new RedisStore<DataType>(client));
-  const store = container.getStore(storeKey) as RedisStore<DataType>;
+  let container: CacheContainer;
+  let client: FakeRedisClient;
+  let storeKey: string;
+  let store: RedisStore<DataType>;
+
+  beforeEach(() => {
+    container = new CacheContainer();
+    client = new FakeRedisClient();
+    storeKey = 'redis';
+    container.addStore(storeKey, new RedisStore<DataType>(client));
+    store = container.getStore(storeKey) as RedisStore<DataType>;
+  });
 
   it('should set and get values', async () => {
     await store.flushAll();
@@ -76,11 +90,104 @@ describe('RedisStore', () => {
     jest.advanceTimersByTime(20);
     jest.runOnlyPendingTimers();
     expect(await store.get('b')).toBeUndefined();
+    expect(store.getMisses()).toBe(1);
     jest.useRealTimers();
   });
 
   it('should expose the underlying client', () => {
     expect(store.getClient()).toBe(client);
   });
-});
 
+  it('should throw error when getting with empty key', async () => {
+    await expect(store.get('')).rejects.toThrow(InvalidArgument);
+    await expect(store.get('')).rejects.toThrow(
+      'cannot get value without a key',
+    );
+  });
+
+  it('should handle non-JSON data gracefully', async () => {
+    // Directly manipulate the fake client to store non-JSON data
+    await client.set('nonJson', 'This is not JSON');
+    const result = await store.get('nonJson');
+    expect(result).toBe('This is not JSON');
+  });
+
+  it('should throw error when setting with empty key', async () => {
+    await expect(store.set('', {name: 'test'})).rejects.toThrow(
+      InvalidArgument,
+    );
+    await expect(store.set('', {name: 'test'})).rejects.toThrow(
+      'cannot set value without a key',
+    );
+  });
+
+  it('should throw error when setting null or undefined', async () => {
+    // @ts-expect-error: Testing invalid input
+    await expect(store.set('key', null)).rejects.toThrow(InvalidArgument);
+    // @ts-expect-error: Testing invalid input
+    await expect(store.set('key', undefined)).rejects.toThrow(InvalidArgument);
+    // @ts-expect-error: Testing invalid input
+    await expect(store.set('key', null)).rejects.toThrow(
+      'cannot set undefined or null',
+    );
+  });
+
+  it('should use defaultTTL if provided and no specific TTL given', async () => {
+    const clientWithOptions = new FakeRedisClient();
+    const storeWithDefaultTTL = new RedisStore<DataType>(clientWithOptions, {
+      defaultTTL: 100,
+    });
+
+    jest.useFakeTimers();
+    await storeWithDefaultTTL.set('defaultTTL', {name: 'default'});
+
+    // Verify it's set with the defaultTTL
+    expect(await storeWithDefaultTTL.get('defaultTTL')).toEqual({
+      name: 'default',
+    });
+
+    // Advance time beyond the defaultTTL
+    jest.advanceTimersByTime(110);
+    jest.runOnlyPendingTimers();
+
+    // Key should be expired
+    expect(await storeWithDefaultTTL.get('defaultTTL')).toBeUndefined();
+    jest.useRealTimers();
+  });
+
+  it('should delete keys and return true if key existed', async () => {
+    await store.set('toDelete', {name: 'deleteMe'});
+    const result = await store.del('toDelete');
+    expect(result).toBe(true);
+    expect(await store.get('toDelete')).toBeUndefined();
+  });
+
+  it('should return false when deleting non-existent key', async () => {
+    const result = await store.del('nonExistent');
+    expect(result).toBe(false);
+  });
+
+  it('should throw error when deleting with empty key', async () => {
+    await expect(store.del('')).rejects.toThrow(InvalidArgument);
+    await expect(store.del('')).rejects.toThrow(
+      'cannot delete value without a key',
+    );
+  });
+
+  it('should get correct size', async () => {
+    await store.flushAll();
+    await store.set('key1', {name: 'one'});
+    await store.set('key2', {name: 'two'});
+    expect(await store.getSize()).toBe(2);
+  });
+
+  it('should return all keys', async () => {
+    await store.flushAll();
+    await store.set('key1', {name: 'one'});
+    await store.set('key2', {name: 'two'});
+    const keys = await store.getKeys();
+    expect(keys).toHaveLength(2);
+    expect(keys).toContain('key1');
+    expect(keys).toContain('key2');
+  });
+});


### PR DESCRIPTION
## Summary
- expose `getClient` on `RedisStore` for advanced Redis usage
- update RedisStore tests for the new method
- document client access in README and update test counts

## Testing
- `npm run compile`
- `npm test` *(lint step fails due to missing ESLint config)*
